### PR TITLE
LCR ignore duplicate trunk

### DIFF
--- a/freeswitch/scripts/astpp/lib/astpp.functions.lua
+++ b/freeswitch/scripts/astpp/lib/astpp.functions.lua
@@ -474,9 +474,13 @@ function get_carrier_rates(destination_number,number_loop_str,ratecard_id,rate_c
 
     Logger.debug("[GET_CARRIER_RATES] Query :" .. query)
     local i = 1
+    local carrier_ignore_duplicate = {}
     assert (dbh:query(query, function(u)
-	    carrier_rates[i] = u
-	    i = i+1
+	    if (carrier_ignore_duplicate[u['trunk_id']] == nil) then
+	    	    carrier_rates[i] = u
+	    	    i = i+1
+		    carrier_ignore_duplicate[u['trunk_id']] = true
+	    end
     end))    
     return carrier_rates
 end


### PR DESCRIPTION
If i have multiple outbound route for the same trunk, it duplicate the bridge

example
PATTERN|TRUNK
^5742._|1
^574._|1
when i call this generate a two bridges for the same trunk, this generate a big delay before get the next valid gateway.
this must be ignore and build one bridge for trunk within the least cost
