### PR TITLE
Create folder for fail2ban pid file

### DIFF
--- a/misc/contribution/Fail2ban.sh
+++ b/misc/contribution/Fail2ban.sh
@@ -123,6 +123,7 @@ bantime  = 6000
 
 
 ################################# JAIL.CONF FILE READY ######################
+mkdir /var/run/fail2ban
 
 echo "################################################################"
 echo "Auto Configuration Completed"


### PR DESCRIPTION
Without the directory /var/run/fail2ban then fail2ban will not start because it is unable to create the pid file /var/run/fail2ban/fail2ban.pid

Once the directory is created then fail2ban is able to run