### PR TITLE
Update astpp.dialplan.lua

### DIFF
--- a/freeswitch/scripts/astpp/scripts/astpp.dialplan.lua
+++ b/freeswitch/scripts/astpp/scripts/astpp.dialplan.lua
@@ -21,6 +21,11 @@
 --------------------------------------------------------------------------------------
 
 destination_number = params:getHeader("Caller-Destination-Number")
+
+if (destination_number == nil) then
+    return;
+end
+
 Logger.info("[Dialplan] Dialed number : "..destination_number)
 
 


### PR DESCRIPTION
I don't know under what conditions destination_number is nil, but found this in my cli

2017-12-04 11:55:17.556167 [ERR] mod_lua.cpp:203 /usr/local/freeswitch/scripts/astpp/scripts/astpp.dialplan.lua:24: attempt to concatenate 
global 'destination_number' (a nil value)
stack traceback:
        /usr/local/freeswitch/scripts/astpp/scripts/astpp.dialplan.lua:24: in main chunk
        [C]: in function 'dofile'
        /usr/local/freeswitch/scripts/astpp/astpp.lua:79: in main chunk
2017-12-04 11:55:17.556167 [ERR] mod_lua.cpp:270 LUA script parse/execute error!