### PR TITLE
Reloadacl while deleting accepted ip

### DIFF
--- a/web_interface/astpp/application/modules/accounts/controllers/accounts.php
+++ b/web_interface/astpp/application/modules/accounts/controllers/accounts.php
@@ -508,9 +508,10 @@ class Accounts extends MX_Controller {
 			) );
 			//To reloadacl in freeswitch when deleting the accepted ip
 			$this->load->library ( 'freeswitch_lib' );
-			$this->load->model ( "freeswitch_model" );
-			$command = "api reloadacl";
-			$this->freeswitch_model->reload_freeswitch ( $command );
+                        $this->load->module ( 'freeswitch/freeswitch' );
+                        $command = "api reloadacl";
+                        $response = $this->freeswitch_model->reload_freeswitch ( $command );
+                        $this->session->set_userdata ( 'astpp_notification', $response );
 			
 			$this->session->set_flashdata ( 'astpp_notification', 'IP removed sucessfully.' );
 		}

--- a/web_interface/astpp/application/modules/accounts/controllers/accounts.php
+++ b/web_interface/astpp/application/modules/accounts/controllers/accounts.php
@@ -506,12 +506,12 @@ class Accounts extends MX_Controller {
 			$ip_flag = $this->db_model->delete ( "ip_map", array (
 					"id" => $ipmapid 
 			) );
-			if ($ip_flag) {
-				$this->load->library ( 'freeswitch_lib' );
-				$this->load->model ( "freeswitch_model" );
-				$command = "api reloadacl";
-				$this->freeswitch_model->reload_freeswitch ( $command );
-			}
+			//To reloadacl in freeswitch when deleting the accepted ip
+			$this->load->library ( 'freeswitch_lib' );
+			$this->load->model ( "freeswitch_model" );
+			$command = "api reloadacl";
+			$this->freeswitch_model->reload_freeswitch ( $command );
+			
 			$this->session->set_flashdata ( 'astpp_notification', 'IP removed sucessfully.' );
 		}
 		redirect ( base_url () . "accounts/" . $accounttype . "_ipmap/" . $accountid . "/" );


### PR DESCRIPTION
ACL module reloading in freeswitch to have affect of deleted ip from customer profile