### PR TITLE
Update database.php

### DIFF
--- a/web_interface/astpp/application/config/database.php
+++ b/web_interface/astpp/application/config/database.php
@@ -52,7 +52,7 @@ $astpp_config = parse_ini_file ( "/var/lib/astpp/astpp-config.conf" );
 
 $active_group = 'default';
 $active_record = TRUE;
-$astpp_config ['astpp_dbengine'] = "MySql";
+$astpp_config ['astpp_dbengine'] = "MySqli";
 $db ['default'] ['hostname'] = $astpp_config ['dbhost'];
 $db ['default'] ['username'] = $astpp_config ['dbuser'];
 $db ['default'] ['password'] = $astpp_config ['dbpass'];


### PR DESCRIPTION
Change mysql driver to mysqli.  Menu still works.  I haven't tested much else beyond that.

mysql driver(extension) is deprecated in PHP 5.5+ and removed completely in PHP v7.  So mysqli should probably be the new default.