### PR TITLE
Fix too few arguments in function insert_parent_data()

### DIFF
--- a/freeswitch/fs/lib/astpp.cdr.php
+++ b/freeswitch/fs/lib/astpp.cdr.php
@@ -146,7 +146,7 @@ function process_cdr($data, $db, $logger, $decimal_points, $config) {
 	
 	// Resellers CDR entry
 	$flag_parent = false;
-	insert_parent_data ( $dataVariable, $actual_calltype, $parentid, $origination_rate, $actual_duration, $provider_cost, $flag_parent, $logger, $db, $decimal_points );
+	insert_parent_data ( $dataVariable, $actual_calltype, $parentid, $origination_rate, $actual_duration, $provider_cost, $flag_parent, $logger, $db, $decimal_points, $config );
 	
 	$logger->log ( "*********************** OUTBOUND CALL ENTRY END *************" );
 	


### PR DESCRIPTION
PHP v7.1 throws an error instead of just a warning.

http://php.net/manual/en/migration71.incompatible.php

 