### PR TITLE
Generate timezone list and calculate GMT offset

### DIFF
--- a/web_interface/astpp/application/libraries/Timezone.php
+++ b/web_interface/astpp/application/libraries/Timezone.php
@@ -38,10 +38,15 @@ class Timezone {
 		$number = ($timezone_id == "") ? $this->uset_timezone () : $timezone_id;
 		$SERVER_GMT = '0';
 		
-		$result = $this->CI->db->query ( "select gmtoffset from timezone where id =" . $number );
-		$timezone_offset = $result->result ();
+		$timestamp = time();
+		$timezone_identifiers = DateTimeZone::listIdentifiers();
+		foreach($timezone_identifiers as $key => $zone) {
+			date_default_timezone_set($zone);
+			$offset = date('Z', $timestamp);
+	        $timezones[$key] = $offset;
+	    }
 		
-		$USER_GMT = $timezone_offset ['0']->gmtoffset;
+		$USER_GMT = $timezones[$number];
 		
 		$date_time_array = getdate ( strtotime ( $currDate ) );
 		

--- a/web_interface/astpp/application/libraries/Timezone.php
+++ b/web_interface/astpp/application/libraries/Timezone.php
@@ -43,7 +43,7 @@ class Timezone {
 		foreach($timezone_identifiers as $key => $zone) {
 			date_default_timezone_set($zone);
 			$offset = date('Z', $timestamp);
-	        $timezones[$key] = $offset;
+	                $timezones[$key] = $offset;
 	    }
 		
 		$USER_GMT = $timezones[$number];

--- a/web_interface/astpp/application/libraries/Timezone.php
+++ b/web_interface/astpp/application/libraries/Timezone.php
@@ -44,7 +44,7 @@ class Timezone {
 			date_default_timezone_set($zone);
 			$offset = date('Z', $timestamp);
 	                $timezones[$key] = $offset;
-	    }
+	    	}
 		
 		$USER_GMT = $timezones[$number];
 		

--- a/web_interface/astpp/application/models/db_model.php
+++ b/web_interface/astpp/application/models/db_model.php
@@ -519,9 +519,9 @@ class Db_model extends CI_Model {
 		foreach($timezone_identifiers as $key => $zone) {
 			date_default_timezone_set($zone);
 			$offset = 'GMT' . date('P', $timestamp);
-	        $timezones[$key] = $offset . ' ' . $zone;
-	    }
-	    return $timezones;	 
+	        	$timezones[$key] = $offset . ' ' . $zone;
+	    	}
+	    	return $timezones;	 
 	}
 
 	function build_dropdown($select, $table, $id_where = '', $id_value = '') {

--- a/web_interface/astpp/application/models/db_model.php
+++ b/web_interface/astpp/application/models/db_model.php
@@ -512,6 +512,18 @@ class Db_model extends CI_Model {
 		}
 		return $drp_list;
 	}
+
+	function timezone_list() {
+		$timestamp = time();
+		$timezone_identifiers = DateTimeZone::listIdentifiers();
+		foreach($timezone_identifiers as $key => $zone) {
+			date_default_timezone_set($zone);
+			$offset = 'GMT' . date('P', $timestamp);
+	        $timezones[$key] = $offset . ' ' . $zone;
+	    }
+	    return $timezones;	 
+	}
+
 	function build_dropdown($select, $table, $id_where = '', $id_value = '') {
 		$select_params = explode ( ',', $select );
 		$where = '';

--- a/web_interface/astpp/application/modules/accounts/libraries/accounts_form.php
+++ b/web_interface/astpp/application/modules/accounts/libraries/accounts_form.php
@@ -2381,7 +2381,7 @@ class Accounts_form {
 						'id',
 						'gmtzone',
 						'timezone',
-						'build_dropdown',
+						'timezone_list',
 						'',
 						'' 
 				),


### PR DESCRIPTION
This modification calculates GMT offset and will therefore display the correct timezone for daylight savings time.

This is demonstration code so only admin form timezone is altered with minimal modification. This will then display reports with the new DST aware timezone calculation when logged in as admin.   To fully implement, change all other references to `timezone` in `accounts_form.php`.  Would also need to be cleaned up to remove several unnecessary things if the change is implemented as is.

Admin account timezone needs to be updated via GUI after the changes so that the `account` table is updated with the new `timezone_id`.  After that you need to logout/login for session data to update to correct `timezone_id`.

Generating the timezone list on the fly does not seem to be very resource intensive. However it could alternatively be put in a table like it is now.

