### PR TITLE
Site Not Secure error when using HTTPS fixed

### DIFF
--- a/web_interface/astpp/assets/css/global-style.css
+++ b/web_interface/astpp/assets/css/global-style.css
@@ -1,5 +1,5 @@
 ﻿@import url(https://fonts.googleapis.com/css?family=Noto+Sans:400,700);
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,500,700);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,500,700);
 .content_border
 {
 	border:1px solid #e7eaec;}


### PR DESCRIPTION
When https is implemented, there's an error that marks site as "not secure" because site uses https but loads scripts that are http.