### PR TITLE
CallerID issue in CDRs records in v3.6 fixed

### DIFF
--- a/freeswitch/scripts/astpp/scripts/astpp.xml.lua
+++ b/freeswitch/scripts/astpp/scripts/astpp.xml.lua
@@ -117,7 +117,7 @@ function freeswitch_xml_header(xml,destination_number,accountcode,maxlength,call
             table.insert(xml, [[<action application="set" data="original_caller_id_name=]]..callerid_array['original_cid_name']..[["/>]]);
     end
     if (callerid_array['cid_number'] ~= '' and callerid_array['cid_number'] ~= '<null>')  then
-            table.insert(xml, [[<action application="set" data="original_caller_id_number=]]..callerid_array['original_cid_name']..[["/>]]);
+            table.insert(xml, [[<action application="set" data="original_caller_id_number=]]..callerid_array['original_cid_number']..[["/>]]);
     end
        
 	return xml


### PR DESCRIPTION
There is a typo in line 120 making cdrs displaying only callerID name and not callerID number.

This issue was found in v3.5 too:
https://github.com/iNextrix/ASTPP/pull/320/files