### PR TITLE
Update opensips mysql connector to mysqli for PHP v7 compatibility

### DIFF
--- a/web_interface/astpp/application/modules/accounts/models/accounts_model.php
+++ b/web_interface/astpp/application/modules/accounts/models/accounts_model.php
@@ -584,7 +584,7 @@ class Accounts_model extends CI_Model {
 			// $this->db->insert_batch('accounts', $insert_array);
 			if ($opensip_flag == 1) {
 				$db_config = Common_model::$global_config ['system_config'];
-				$opensipdsn = "mysql://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
+				$opensipdsn = "mysqli://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
 				$this->opensips_db = $this->load->database ( $opensipdsn, true );
 				$this->opensips_db->insert_batch ( "subscriber", $opensips_array );
 			}

--- a/web_interface/astpp/application/modules/opensips/models/opensips_model.php
+++ b/web_interface/astpp/application/modules/opensips/models/opensips_model.php
@@ -24,7 +24,7 @@ class Opensips_model extends CI_Model {
 	function Opensips_model() {
 		parent::__construct ();
 		$db_config = Common_model::$global_config ['system_config'];
-		$opensipdsn = "mysql://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
+		$opensipdsn = "mysqli://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
 		$this->opensips_db = $this->load->database ( $opensipdsn, true );
 	}
 	function getopensipsdevice_list($flag, $start = 0, $limit = 0) {

--- a/web_interface/astpp/application/modules/user/controllers/user.php
+++ b/web_interface/astpp/application/modules/user/controllers/user.php
@@ -1924,7 +1924,7 @@ class User extends MX_Controller {
 	function user_opensips_edit($edit_id) {
 		$data ['page_title'] = gettext ( 'Edit Opensips' );
 		$db_config = Common_model::$global_config ['system_config'];
-		$opensipdsn = "mysql://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
+		$opensipdsn = "mysqli://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
 		$this->opensips_db = $this->load->database ( $opensipdsn, true );
 		$where = array (
 				'id' => $edit_id 
@@ -1983,7 +1983,7 @@ class User extends MX_Controller {
 	function validate_device_data($data) {
 		if (isset ( $data ["username"] ) && $data ["username"] != "") {
 			$db_config = Common_model::$global_config ['system_config'];
-			$opensipdsn = "mysql://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
+			$opensipdsn = "mysqli://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
 			$this->opensips_db = $this->load->database ( $opensipdsn, true );
 			$where = array (
 					"username" => $data ["username"] 
@@ -2015,7 +2015,7 @@ class User extends MX_Controller {
 	}
 	function user_opensips_delete_multiple() {
 		$db_config = Common_model::$global_config ['system_config'];
-		$opensipdsn = "mysql://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
+		$opensipdsn = "mysqli://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
 		$this->opensips_db = $this->load->database ( $opensipdsn, true );
 		$ids = $this->input->post ( "selected_ids", true );
 		$where = "id IN ($ids)";

--- a/web_interface/astpp/application/modules/user/models/user_model.php
+++ b/web_interface/astpp/application/modules/user/models/user_model.php
@@ -26,7 +26,7 @@ class user_model extends CI_Model {
 		parent::__construct ();
 		if (Common_model::$global_config ['system_config'] ['opensips'] == 0) {
 			$db_config = Common_model::$global_config ['system_config'];
-			$opensipdsn = "mysql://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
+			$opensipdsn = "mysqli://" . $db_config ['opensips_dbuser'] . ":" . $db_config ['opensips_dbpass'] . "@" . $db_config ['opensips_dbhost'] . "/" . $db_config ['opensips_dbname'] . "?char_set=utf8&dbcollat=utf8_general_ci&cache_on=true&cachedir=";
 			$this->opensips_db = $this->load->database ( $opensipdsn, true );
 		}
 	}


### PR DESCRIPTION
Update the hardlink references to mysqli for compatibility with PHP v7.  This gets the menus working on a PHP v7.1 install.
