### PR TITLE
Add ability to remap numbers for billing simplification

### DIFF
--- a/freeswitch/scripts/astpp/scripts/astpp.dialplan.lua
+++ b/freeswitch/scripts/astpp/scripts/astpp.dialplan.lua
@@ -20,14 +20,15 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --------------------------------------------------------------------------------------
 
-destination_number = params:getHeader("Caller-Destination-Number")
+orig_destination_number = params:getHeader("Caller-Destination-Number")
 
-if (destination_number == nil) then
+if (orig_destination_number == nil) then
     return;
 end
 
-Logger.info("[Dialplan] Dialed number : "..destination_number)
-
+Logger.info("[Dialplan] Original Dialed number : "..orig_destination_number)
+destination_number = remap_dest_number(orig_destination_number)
+Logger.info("[Dialplan] Remapped  Dialed number : "..destination_number)
 
 --Check if dialed number is calling card access number
 if (config['cc_access_numbers'] ~= '') then 


### PR DESCRIPTION
Note there's no GUI for this, as it's unlikely that this will ever need to be changed in a real-world situation.

This is what I'm using for Australia, as an example

```
+--------+-------+
| prefix | remap |
+--------+-------+
| 07     | 617   |
| 04     | 614   |
| 02     | 612   |
| 03     | 613   |
| 08     | 618   |
| 0011   |       |
+--------+-------+

```
