### PR TITLE
Currency import using 1forge.com API & add conversion loss % calculation

### DIFF
--- a/database/astpp-upgrade-3.6.sql
+++ b/database/astpp-upgrade-3.6.sql
@@ -61,6 +61,9 @@ VALUES(219,'realtime_billing','Realtime Billing <b>(<a href=\'http://astpp.readt
 billing.',NULL,0,0,'global'); 
 INSERT INTO `system` (`id`, `name`, `display_name`, `value`, `field_type`, `comment`, `timestamp`, `reseller_id`, `brand_id`, `group_title`) VALUES ('0', 'homer_capture_server', 'Capture Server', '', 'default_system_input', 'Set enable to capture logs in homer. Format : udp:192.168.1.200:9060', NULL, '0', '0', 'homer');
 UPDATE `system` SET `display_name` = 'Default Invoice Mode', `comment` = 'Draft will give possibility to admin and reseller to modify invoice after generation whereas Confirmed invoices will be readonly.' WHERE `system`.`id` = 216;
+-- add entries for currency update, added by Alex Heylin re https://github.com/iNextrix/ASTPP/issues/445
+insert into astpp.system (`id`, `name`, `display_name`, `value`, `field_type`, `comment`, `reseller_id`, `brand_id`, `group_title`) VALUES  (222, "currency_conv_loss_pct", "Currency Conversion Loss Percentage", 20, "default_system_input", "What percentage to allow for currency conversion losses", 0, 0, "global");
+insert into astpp.system (`id`, `name`, `display_name`, `value`, `field_type`, `comment`, `reseller_id`, `brand_id`, `group_title`) VALUES  (221, "currency_conv_api_key", "API key for currency rate import from 1forge.com", "YourKeyGoesHere", "default_system_input", "", 0, 0, "global");
 
 --
 -- add call request field in CDRs

--- a/database/astpp-upgrade-3.7.sql
+++ b/database/astpp-upgrade-3.7.sql
@@ -1,0 +1,3 @@
+-- add entries for currency update, added by Alex Heylin re https://github.com/iNextrix/ASTPP/issues/445
+insert into astpp.system (`id`, `name`, `display_name`, `value`, `field_type`, `comment`, `reseller_id`, `brand_id`, `group_title`) VALUES  (222, "currency_conv_loss_pct", "Currency Conversion Loss Percentage", 20, "default_system_input", "What percentage to allow for currency conversion losses", 0, 0, "global");
+insert into astpp.system (`id`, `name`, `display_name`, `value`, `field_type`, `comment`, `reseller_id`, `brand_id`, `group_title`) VALUES  (221, "currency_conv_api_key", "API key for currency rate import from 1forge.com", "YourKeyGoesHere", "default_system_input", "", 0, 0, "global");

--- a/web_interface/astpp/application/controllers/currencyupdate.php
+++ b/web_interface/astpp/application/controllers/currencyupdate.php
@@ -33,7 +33,7 @@ class Currencyupdate extends CI_Controller {
 		// exit();
 		$this->load->model ( "db_model" );
 		$this->load->library ( "astpp/common" );
-        $this->fp = fopen("/var/log/astpp/astpp-currency.log", "a+");
+        $this->fp = fopen( Common_model::$global_config ['system_config'] ['log_path'] ."/astpp-currency.log", "a+");
 	}
 
     function update_currency() {

--- a/web_interface/astpp/application/controllers/currencyupdate.php
+++ b/web_interface/astpp/application/controllers/currencyupdate.php
@@ -24,72 +24,108 @@
 
 
 class Currencyupdate extends CI_Controller {
+
+    public $fp = "";
+
 	function __construct() {
 		parent::__construct ();
 		// if(!defined( 'CRON' ) )
 		// exit();
 		$this->load->model ( "db_model" );
 		$this->load->library ( "astpp/common" );
+        $this->fp = fopen("/var/log/astpp/astpp-currency.log", "a+");
 	}
 
     function update_currency() {
         $apiKey = Common_model::$global_config ['system_config'] ['currency_conv_api_key'];
+        $errMsg = "" ;
         if (Common_model::$global_config ['system_config'] ['currency_conv_api_key'] != ""
             && Common_model::$global_config ['system_config'] ['currency_conv_api_key'] != "YourKeyGoesHere"
         ) {
+            // Get list of available symbols matching the base currency
             $baseCurrency = Common_model::$global_config ['system_config'] ['base_currency'];
             $url = "https://forex.1forge.com/1.0.3/symbols?api_key=".$apiKey."";
             $symbolsData = $this->curl_response ( $url );
             $symbolsData = json_decode($symbolsData);
-            $symbolString = "" ;
-            foreach ($symbolsData as $symbol) {
-                if ( substr($symbol,0, 3) == $baseCurrency ) {
-                    $curQry = "select currency from astpp.currency WHERE currency REGEXP '[A-Z][A-Z][A-Z]';";
-                    $curData = $this->db->query($curQry);
-                    if ($curData->num_rows() > 0) {
-                        $currency_arr = $curData->result_array();
-                        foreach ( $currency_arr  as $currency ) {
-                            foreach ($currency  as $key => $value ) {
-                                if (strtolower($value) == strtolower(substr($symbol, 3, 3))) {
-                                    if ($symbolString == "") {
-                                        $symbolString = $symbol;
-                                    } else {
-                                        $symbolString = $symbolString . "," . $symbol;
+            if ($symbolsData === null || json_last_error() !== JSON_ERROR_NONE || empty($symbolsData)) {
+                $errMsg .= "JSON decode of symbol list from API failed.  ";
+            } else {
+                $symbolString = "";
+                foreach ($symbolsData as $symbol) {
+                    if (substr($symbol, 0, 3) == $baseCurrency) {
+                        $curQry = "select currency from astpp.currency WHERE currency REGEXP '[A-Z][A-Z][A-Z]';";
+                        $curData = $this->db->query($curQry);
+                        if ($curData->num_rows() > 0) {
+                            // Roll the matching symbols into a list to get values for
+                            $currency_arr = $curData->result_array();
+                            foreach ($currency_arr as $currency) {
+                                foreach ($currency as $key => $value) {
+                                    if (strtolower($value) == strtolower(substr($symbol, 3, 3))) {
+                                        if ($symbolString == "") {
+                                            $symbolString = $symbol;
+                                        } else {
+                                            $symbolString = $symbolString . "," . $symbol;
+                                        }
                                     }
                                 }
                             }
+                        } else {
+                            // No currency returned from DB!
+                            $errMsg .= "No currency returned from DB.  ";
+                        }
+                    }
+                }
+
+                if ($symbolString == "") {
+                    $errMsg .= "Symbol string is empty, unable to request rates from API.  ";
+                } else {
+                    // Get the values for the list of symbols
+                    $url = "https://forex.1forge.com/1.0.3/quotes?pairs=" . $symbolString . "&api_key=" . $apiKey . "";
+                    $quotesData = $this->curl_response($url);
+                    $quotesData = json_decode($quotesData);
+
+                    if ($quotesData === null || json_last_error() !== JSON_ERROR_NONE || empty($quotesData)) {
+                        $errMsg .= "JSON decode of currency rates from API failed.  ";
+                    } else {
+
+                        foreach ($quotesData as $quote) {
+
+                            if (isset(Common_model::$global_config ['system_config'] ['currency_conv_loss_pct'])
+                                && (Common_model::$global_config ['system_config'] ['currency_conv_loss_pct'] > 0)
+                                && (Common_model::$global_config ['system_config'] ['currency_conv_loss_pct'] < 100)
+                            ) {
+
+                                $value = ($quote->price * (1 - (Common_model::$global_config ['system_config'] ['currency_conv_loss_pct'] / 100)));
+                            } else {
+
+                                $value = $quote->price;
+                            }
+                            $curSymbol = strtoupper(substr($quote->symbol, 3, 3));
+
+                            $sql = "UPDATE currency SET currencyrate = '" . $value . "',last_updated = now() WHERE currency = '" . $curSymbol . "'\n";
+
+                            if (!$this->db->query($sql)) {
+                                $errMsg .= "Error writing SQL [" . $sql . "] to DB.  ";
+                            };
+                        }
+                        $updatebasecurrency = "UPDATE currency SET currencyrate = '1.000',last_updated = now() WHERE currency = '" . Common_model::$global_config ['system_config'] ['base_currency'] . "'";
+
+
+                        if (!$this->db->query($updatebasecurrency)) {
+                            $errMsg .= "Error writing SQL [" . $updatebasecurrency . "] to DB.  ";
                         }
                     }
                 }
             }
-
-            $url = "https://forex.1forge.com/1.0.3/quotes?pairs=".$symbolString."&api_key=".$apiKey."";
-            $quotesData = $this->curl_response ( $url );
-            $quotesData = json_decode($quotesData);
-            $debugstring = "";
-            foreach ($quotesData as $quote) {
-                $debugstring = $debugstring . "A," ;
-                if (isset(Common_model::$global_config ['system_config'] ['currency_conv_loss_pct'])
-                    && (Common_model::$global_config ['system_config'] ['currency_conv_loss_pct'] > 0 )
-                    && (Common_model::$global_config ['system_config'] ['currency_conv_loss_pct'] < 100)
-                ) {
-                    $debugstring = $debugstring . "B," ;
-                    $value = ($quote->price * (1 - ( Common_model::$global_config ['system_config'] ['currency_conv_loss_pct'] / 100)));
-                } else {
-                    $debugstring = $debugstring . "C," ;
-                    $value = $quote->price;
-                }
-                $curSymbol = strtoupper(substr($quote->symbol,3, 3));
-                $debugstring = $debugstring . "D_" . $curSymbol . ":" . $value . "," ;
-                $sql = "UPDATE currency SET currencyrate = '".$value."',last_updated = now() WHERE currency = '" . $curSymbol . "'\n";
-                $debugstring = $debugstring . $sql ;
-                $this->db->query ( $sql );
+            if ($errMsg == "") {
+                fwrite($this->fp, gmdate("Y-m-d H:i:s") . " Currency exchange rates successfully updated for " . $symbolString . "\n");
+                $this->session->set_flashdata("astpp_errormsg", "Currency exchange rates successfully updated.");
+            } else {
+                fwrite($this->fp, gmdate("Y-m-d H:i:s") . " ERROR: " . $errMsg  . " for " . $symbolString . "\n");
+                $this->session->set_flashdata ( "astpp_notification", "ERROR: " . $errMsg );
             }
-            $updatebasecurrency = "UPDATE currency SET currencyrate = '1.000',last_updated = now() WHERE currency = '" . Common_model::$global_config ['system_config'] ['base_currency'] . "'";
-            $this->db->query ( $updatebasecurrency );
-            $this->session->set_flashdata ( "astpp_errormsg", "Currency exchange rates successfully updated." );
+            redirect(base_url() . "/systems/currency_list/");
 
-            redirect ( base_url () . "/systems/currency_list/" );
         } else {
             $this->session->set_flashdata ( "astpp_notification", "You must enter your API key for 1forge.com." );
             redirect ( base_url () . "/systems/configuration/global" );


### PR DESCRIPTION
Currency import using 1forge.com API
Add conversion loss % calculation
Add two fields to system table to support this.

Note: need to import SQL manually for now, as expecting this to be integrated into v3.7 upgrade file.