### PR TITLE
Fixed Fail2Ban Downloads

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -447,8 +447,8 @@ install_fail2ban()
                             read -p "Enter sender email address: ${NOTISENDEREMAIL}"
                             NOTISENDEREMAIL=${REPLY}
                             cd /usr/src
-                            wget --no-check-certificate https://latest.astppbilling.org/fail2ban_Deb.tar.gz
-                            tar xzvf fail2ban_Deb8.tar.gz
+                            wget --no-check-certificate --max-redirect=0 http://latest.astppbilling.org/fail2ban_Deb.tar.gz
+                            tar xzvf fail2ban_Deb.tar.gz
                             rm -rf /etc/fail2ban
                             cp -rf /usr/src/fail2ban /etc/fail2ban
                                 echo '[DEFAULT]
@@ -554,8 +554,8 @@ bantime  = 7200' >> /etc/fail2ban/jail.local
                             read -p "Enter sender email address: ${NOTISENDEREMAIL}"
                             NOTISENDEREMAIL=${REPLY}
                             cd /usr/src
-                            wget --no-check-certificate https://latest.astppbilling.org/fail2ban_Cent.tar.gz
-                            tar xzvf fail2ban_Cent7.tar.gz
+                                                        wget --no-check-certificate --max-redirect=0 http://latest.astppbilling.org/fail2ban_Cent.tar.gz
+                            tar xzvf fail2ban_Cent.tar.gz
                             rm -rf /etc/fail2ban
                             cp -rf /usr/src/fail2ban /etc/fail2ban
                                 echo '[DEFAULT]


### PR DESCRIPTION
Fixed Fail2Ban Download URLs and Extracts
This makes the commands work correctly now it does NOT fix the issues inside the packages provided by ASTPP.
ASTPP is refusing https requests via the https url and the extract command still had the old filename which I changed.
Note: For Deb if you don't do the no redirect it'll try to use https since deb9 is trying to make everything HTTPS now.