### PR TITLE
[FIX] Configuration - Purge - "Invoices" spelling is wrong display

### DIFF
--- a/database/change_160920.sql
+++ b/database/change_160920.sql
@@ -1,0 +1,3 @@
+-- -----------Configuration - Purge - "Invoices" spelling is wrong displayed query. Date of change : 160920 change_by : Bhargav 
+
+UPDATE `system` SET `display_name` = 'Invoices Older Than Days' WHERE `system`.`name` = "purge_invoices";


### PR DESCRIPTION
Note : Configuration - Purge - "Invoices" spelling is wrong displaye issue fixed.

jira link : https://jira.astppbilling.org/browse/ASTPPCOM-627