### PR TITLE
Fix lua debug not working

### DIFF
--- a/freeswitch/scripts/astpp-callingcards.lua
+++ b/freeswitch/scripts/astpp-callingcards.lua
@@ -68,7 +68,7 @@ if (not params) then
 end
 
 
-if (config['debug']==1) then
+if (config['debug'] == '0') then
     -- print all params 
     if (params:serialize() ~= nil) then
     	Logger.notice ("[xml_handler] Params:\n" .. params:serialize())

--- a/freeswitch/scripts/astpp/astpp.lua
+++ b/freeswitch/scripts/astpp/astpp.lua
@@ -71,7 +71,7 @@ if (not params) then
 	end
 end
 
-if (config['debug']==2) then
+if (config['debug'] == '0') then
     -- print all params 
     if (params:serialize() ~= nil) then
     	Logger.notice ("[xml_handler] Params:\n" .. params:serialize())


### PR DESCRIPTION
Lua debug never gets activated when `Configuration > Settings > Calls > Debug = Enable`.  This fixes that.