### PR TITLE
Fix removed feature

### DIFF
--- a/web_interface/astpp/application/modules/freeswitch/libraries/freeswitch_form.php
+++ b/web_interface/astpp/application/modules/freeswitch/libraries/freeswitch_form.php
@@ -217,7 +217,7 @@ class Freeswitch_form extends common
                     'size' => '20',
                     'class' => "text field medium"
                 ),
-                '',
+                'xss_clean',
                 'tOOL TIP',
                 'Please Enter account number'
             ),
@@ -229,7 +229,7 @@ class Freeswitch_form extends common
                     'size' => '20',
                     'class' => "text field medium"
                 ),
-                '',
+                'xss_clean',
                 'tOOL TIP',
                 'Please Enter account number'
             ),
@@ -2744,7 +2744,7 @@ class Freeswitch_form extends common
                         'size' => '20',
                         'class' => "text field medium"
                     ),
-                    '',
+                    'xss_clean',
                     'tOOL TIP',
                     'Please Enter account number'
                 ),
@@ -2756,7 +2756,7 @@ class Freeswitch_form extends common
                         'size' => '20',
                         'class' => "text field medium"
                     ),
-                    '',
+                    'xss_clean',
                     'tOOL TIP',
                     'Please Enter account number'
                 ),
@@ -2980,7 +2980,7 @@ class Freeswitch_form extends common
                         'size' => '20',
                         'class' => "text field medium"
                     ),
-                    '',
+                    'xss_clean',
                     'tOOL TIP',
                     'Please Enter account number'
                 ),
@@ -2992,7 +2992,7 @@ class Freeswitch_form extends common
                         'size' => '20',
                         'class' => "text field medium"
                     ),
-                    '',
+                    'xss_clean',
                     'tOOL TIP',
                     'Please Enter account number'
                 ),

--- a/web_interface/astpp/application/modules/invoices/libraries/invoices_form.php
+++ b/web_interface/astpp/application/modules/invoices/libraries/invoices_form.php
@@ -925,7 +925,7 @@ class invoices_form extends common
                     'size' => '20',
                     'class' => "text field medium"
                 ),
-                'required',
+                'required|xss_clean',
                 'tOOL TIP',
                 'Please Enter account number'
             ),
@@ -1217,7 +1217,7 @@ class invoices_form extends common
                     'maxlength' => '100',
                     'class' => "text field medium"
                 ),
-                '',
+                'xss_clean',
                 'tOOL TIP',
                 ''
             ),

--- a/web_interface/astpp/application/modules/systems/libraries/system_form.php
+++ b/web_interface/astpp/application/modules/systems/libraries/system_form.php
@@ -81,7 +81,7 @@ class System_form extends common
                     'size' => '20',
                     'class' => "description form-control form-control-lg  mt-5"
                 ),
-                'trim|required',
+                'trim|required|xss_clean',
                 'tOOL TIP',
                 ''
             ),

--- a/web_interface/astpp/application/modules/user/libraries/user_form.php
+++ b/web_interface/astpp/application/modules/user/libraries/user_form.php
@@ -1886,7 +1886,7 @@ class User_form extends common
                     'size' => '20',
                     'class' => "text field medium"
                 ),
-                '',
+                'xss_clean',
                 'tOOL TIP',
                 'Please Enter account number'
             ),
@@ -1898,7 +1898,7 @@ class User_form extends common
                     'size' => '20',
                     'class' => "text field medium"
                 ),
-                '',
+                'xss_clean',
                 'tOOL TIP',
                 'Please Enter account number'
             ),

--- a/web_interface/astpp/system/core/Security.php
+++ b/web_interface/astpp/system/core/Security.php
@@ -403,9 +403,9 @@ class CI_Security {
 				$str = preg_replace_callback("#<img\s+([^>]*?)(\s?/?>|$)#si", array($this, '_js_img_removal'), $str);
 			}
 
-			if (preg_match("/script/i", $str) OR preg_match("/xss/i", $str))
+			if (preg_match("/script/i", $str) OR preg_match("/xss/i", $str) OR preg_match("/svg/i", $str))
 			{
-				$str = preg_replace("#<(/*)(script|xss)(.*?)\>#si", '[removed]', $str);
+				$str = preg_replace("#<(/*)(script|xss|svg)(.*?)\>#si", '[removed]', $str);
 			}
 		}
 		while ($original != $str);

--- a/web_interface/astpp/system/core/Security.php
+++ b/web_interface/astpp/system/core/Security.php
@@ -509,8 +509,15 @@ class CI_Security {
 		}
 
 		$str = html_entity_decode($str, ENT_COMPAT, $charset);
-		$str = preg_replace('~&#x(0*[0-9a-f]{2,5})~ei', 'chr(hexdec("\\1"))', $str);
-		return preg_replace('~&#([0-9]{2,4})~e', 'chr(\\1)', $str);
+
+		if(version_compare(PHP_VERSION,5.5,'>=')){
+			$str = preg_replace_callback('~&#x(0*[0-9a-f]{2,5})~i', function(){return chr(hexdec('\\1'));}, $str, -1, $matches);
+			$str = preg_replace_callback('~&#([0-9]{2,4})~', function(){return chr('\\1');}, $str, -1, $matches1);
+		}else{
+			$str = preg_replace('~&#x(0*[0-9a-f]{2,5})~ei', 'chr(hexdec("\\1"))', $str, -1, $matches);
+			$str = preg_replace('~&#([0-9]{2,4})~e', 'chr(\\1)', $str, -1, $matches1);
+		}
+		return $str;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
This was deprecated in PHP v5.5 and removed in PHP v7 so entity_decode() does not work on newer installs.  It may not be a bad idea to consider updating CodeIgnitor to a newer version to fix a lot of these things.  I think this fix is incorporated in v2.2.1. 