### PR TITLE
Fix CodeIgnitor preg_replace() "e" modifier feature which has been removed from PHP

### DIFF
--- a/web_interface/astpp/system/core/Security.php
+++ b/web_interface/astpp/system/core/Security.php
@@ -509,8 +509,15 @@ class CI_Security {
 		}
 
 		$str = html_entity_decode($str, ENT_COMPAT, $charset);
-		$str = preg_replace('~&#x(0*[0-9a-f]{2,5})~ei', 'chr(hexdec("\\1"))', $str);
-		return preg_replace('~&#([0-9]{2,4})~e', 'chr(\\1)', $str);
+		
+		if(version_compare(PHP_VERSION,5.5,'>=')){
+			$str = preg_replace_callback('~&#x(0*[0-9a-f]{2,5})~i', function(){return chr(hexdec('\\1'));}, $str, -1, $matches);
+			$str = preg_replace_callback('~&#([0-9]{2,4})~', function(){return chr('\\1');}, $str, -1, $matches1);
+		}else{
+			$str = preg_replace('~&#x(0*[0-9a-f]{2,5})~ei', 'chr(hexdec("\\1"))', $str, -1, $matches);
+			$str = preg_replace('~&#([0-9]{2,4})~e', 'chr(\\1)', $str, -1, $matches1);
+		}
+		return $str;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
As documented here https://github.com/bcit-ci/CodeIgniter/issues/2681

Here is the commit they merged.
https://github.com/inexorgame-obsolete/community-site-deprecated/commit/dcc7c541bebe183516d08899bff8c654ff4acb01

I don't think `entity_decode()` works at all on any install using PHP > 5.5 without this fix.  
