### PR TITLE
Modified for login.php security flaw. 

### DIFF
--- a/web_interface/astpp/application/modules/login/controllers/login.php
+++ b/web_interface/astpp/application/modules/login/controllers/login.php
@@ -584,7 +584,14 @@ class Login extends MX_Controller
 
     function relogin($new_login_id, $master_id = '0')
     {
-        $where = array(
+     // Check if the user is logged in
+    if (!$this->session->userdata('user_login')) {
+        // Optionally log this event or display an error message before redirecting
+        redirect(base_url() . 'login/');
+        return;
+    }
+
+    $where = array(
             'id' => $new_login_id
         );
         $account_res = (array) $this->db->get_where("accounts", $where)->first_row();


### PR DESCRIPTION
Attacker could access site without the need to login by appending URL with /relogin/<account_number>